### PR TITLE
#83-bugfix-aufgabenbewertung

### DIFF
--- a/FrontEnd/src/components/teacher/EvaluateTaskPage.js
+++ b/FrontEnd/src/components/teacher/EvaluateTaskPage.js
@@ -84,7 +84,7 @@ function evaluateTaskPage(props) {
                 })
             })
         alert("Bewertungen wurden übermittelt");
-        props.switchContent(TASKS_FOR_COURSE_IDENTIFIER)
+        props.switchContent(props.previousContent);
     }
 
     let studentEvaluationDataArray = [];
@@ -175,6 +175,7 @@ const mapStateToProps = state => {
         request_token: state.loginReducer.request_token,
         taskId: state.teacherNavigationReducer.taskId,
         taskTitle: state.teacherNavigationReducer.taskTitle,
+        previousContent: state.teacherNavigationReducer.previousContent,
     }
 }
 

--- a/FrontEnd/src/reducers/teacherNavigationReducer.js
+++ b/FrontEnd/src/reducers/teacherNavigationReducer.js
@@ -7,7 +7,7 @@ const DEFAULT_STATE = {activeContent: SUBJECT_OVERVIEW_IDENTIFIER}
 export default (state = DEFAULT_STATE, action) => {
     switch(action.type){
       case SWITCH_TO_CONTENT:
-            return {...state, activeContent: action.newContentIdentifier};
+            return {...state, activeContent: action.newContentIdentifier, previousContent: state.activeContent};
         case SHOW_EVALUATE_TASK_PAGE:
             return {...state, taskId: action.taskId, taskTitle: action.taskTitle};
         case ERROR_CONTENT_IDENTIFIER:


### PR DESCRIPTION
switchToContent speichert jetzt, welcher content vorher angezeigt wurde
EvaluatetaskPage leitet nun auf den zuletzt angezeigten Content zurück